### PR TITLE
Q39 only has one valid answer but request two

### DIFF
--- a/silver.md
+++ b/silver.md
@@ -764,7 +764,7 @@ puts bar.var
 
 ---------------------------------------------------------------------------
 
-**Q39. Which of the following can be inserted into `__(1)__`  in order for the given code to generate the output below? (Choose two.)**
+**Q39. Which of the following can be inserted into `__(1)__`  in order for the given code to generate the output below? (Choose one.)**
 
 ```
 puts "$foo$".__(1)__("$")


### PR DESCRIPTION
Ruby Silver Prep Q39 requests to select two answers but actually there is only one correct answer according to https://github.com/ruby-association/prep-test/blob/version3/silver_answers.md.

I fixed the Q39 question to ask only for one answer