### PR TITLE
Remove the English description of gold_answers_ja A37

### DIFF
--- a/gold_answers_ja.md
+++ b/gold_answers_ja.md
@@ -287,8 +287,6 @@ ScriptError < Exception
 
 **A37:** (B)
 
-In class methods, `self` refers to an instance of the `Class` object.
-In instance methods, `self` refers to whatever the currently instantiated object is.
 クラスメソッドでは、`self`は`Class`インスタンスを参照します。
 インスタンスメソッドでは、`self`は現在インスタンス化されているオブジェクトを参照します。
 


### PR DESCRIPTION
I would like to remove the English explains in the Japanese answers.

@shugo 
Nice to meet you and if you have time, please review.